### PR TITLE
Avoid double update for other plugins

### DIFF
--- a/src/EarlyUpdateCheck.cs
+++ b/src/EarlyUpdateCheck.cs
@@ -788,14 +788,15 @@ namespace EarlyUpdateCheck
 		private delegate string GetUpdateUrl(string baseurl, UpdateInfo upd, string language);
 		private string GetUpdateUrlSF(string baseurl, UpdateInfo upd, string language)
 		{
-			if (language == null)
-				return baseurl + "files/latest/download";
-			return baseurl + "files/Translations/" + language + "/download";
+			//Only convert Sourceforge url to Github url
+			//All new releases for plugins will be released on Github
+			baseurl = baseurl.Replace("https://sourceforge.net/projects/", "https://github.com/rookiestyle/");
+			return GetUpdateUrlGH(baseurl, upd, language);
 		}
 
 		private string GetUpdateUrlGH(string baseurl, UpdateInfo upd, string language)
 		{
-			if (language == null)
+			if (string.IsNullOrEmpty(language))
 				return baseurl + "releases/download/v" + upd.VersionAvailable.ToString() + "/" + upd.Name + ".plgx";
 			return baseurl.Replace("github.com", "raw.githubusercontent.com") + "master/Translations/" + language;
 		}

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can use the default the Revision and 
 // Build Numbers by using the '*' as shown below:
-[assembly: AssemblyVersion("2.0")]
-[assembly: AssemblyFileVersion("2.0")]
+[assembly: AssemblyVersion("2.0.1")]
+[assembly: AssemblyFileVersion("2.0.1")]
 [assembly: Guid("672570AF-CC57-4980-86F9-D48FD1CC707D")]

--- a/version.info
+++ b/version.info
@@ -1,5 +1,5 @@
 :
-Early update check:2.0
+Early update check:2.0.1
 Early update check!de:3
 Early update check!ru:2
 :


### PR DESCRIPTION
Replace Sourceforge update URL by Github update URL of other plugins.

Pro: Users of my other plugins can use EarlyUpdatecheck to update to the current version of my other plugins with a single click

Con: All updates to my other plugins MUST be published on Github